### PR TITLE
Adding an app-restart app_ready function

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -1,6 +1,15 @@
----
+<% if fog_file = File.expand_path('~/.fog') and File.exists?(fog_file)
+  fog_file = YAML.load_file(fog_file)
+  ENV['AWS_ACCESS_KEY_ID'] ||= fog_file.fetch('travis-ci', {})['aws_access_key_id']
+  ENV['AWS_SECRET_ACCESS_KEY'] ||= fog_file.fetch('travis-ci', {})['aws_secret_access_key']
+  ENV['AWS_KEYPAIR_NAME'] ||= fog_file.fetch('travis-ci', {})['aws_keypair_name']
+  ENV['EC2_SSH_KEY_PATH'] ||= File.expand_path('~/.ssh/id_rsa_kitchen_ec2')
+end %>
 driver:
-  name: vagrant
+  aws_access_key_id: <%= ENV['AWS_ACCESS_KEY_ID'] %>
+  aws_secret_access_key: <%= ENV['AWS_SECRET_ACCESS_KEY'] %>
+  aws_ssh_key_id: <%= ENV['AWS_KEYPAIR_NAME'] %>
+  require_chef_omnibus: "11.4.4"
 provisioner:
   name: chef_solo
   attributes:
@@ -8,8 +17,9 @@ provisioner:
       local_ipv4: "10.0.0.3"
     app_restart:
       restart_command: "echo restart"
+      app_ready_command: "sleep 4"
     rolling_restart:
-      restart_command: "rolling_restart"
+      app_command: "rolling_restart"
       ssh:
         user: "deploy"
         public_key: "ssh-rsa IAMAPUBLICKEY"
@@ -30,9 +40,20 @@ provisioner:
               private_ip: "10.0.0.4"
 
 platforms:
-  - name: centos-6.6
+  - name: amazon-2014.10
+    driver_plugin: ec2
     driver_config:
-      require_chef_omnibus: "11.4 -d /tmp/vagrant-cache/vagrant_omnibus"
+      ssh_key: <%= ENV['EC2_SSH_KEY_PATH'] %>
+      username: ec2-user
+      flavor_id: c3.large
+      image_id: ami-b66ed3de
+      region: us-east-1
+      availability_zone: us-east-1b
+      security_group_ids: ['ci-testing']
+      interface: public
+      tags:
+        Name: <%= "#{ENV['CI'] ? 'travis-ci' : ENV['USER']}-opsworks-rolling-restart-test-kitchen" %>
+        Env: public
 suites:
   - name: default
     run_list:

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -19,7 +19,7 @@ provisioner:
       restart_command: "echo restart"
       app_ready_command: "sleep 4"
     rolling_restart:
-      app_command: "rolling_restart"
+      restart_command: "rolling_restart"
       ssh:
         user: "deploy"
         public_key: "ssh-rsa IAMAPUBLICKEY"

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,12 @@
 source 'https://rubygems.org'
 
-gem 'berkshelf', '2.0.18'
 gem 'test-kitchen'
-gem 'kitchen-vagrant'
+gem 'berkshelf', '2.0.18'
+gem 'fog', '~>1.24.0'
+gem 'fog-core', '~>1.24.0'
+gem 'kitchen-ec2'
 gem 'serverspec'
+
+group :development do
+  gem 'chef', '~>11.4.4'
+end

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -21,6 +21,7 @@ default[:app_restart][:restart_bin] = 'app-restart'
 default[:app_restart][:restart_template] = 'app-restart.sh.erb'
 
 default[:app_restart][:app_running_command] = 'curl --silent --fail --max-time 5 127.0.0.1:$PORT/okcomputer'
+default[:app_restart][:app_ready_command] = ''
 default[:app_restart][:finished_requests_command] = 'sleep 10'
 default[:app_restart][:app_port] = 81
-default[:app_restart][:timeout] = 60
+default[:app_restart][:retries] = 10

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'platform-ops@sportngin.com'
 license          'MIT'
 description      'Provides a rolling restart orchistration to be used with on any appliction with a single restart command'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.markdown'))
-version          '0.1.0'
+version          '0.2.0'
 
 supports 'redhat'
 

--- a/templates/default/app-restart.sh.erb
+++ b/templates/default/app-restart.sh.erb
@@ -1,5 +1,5 @@
 #!/bin/bash
-RETRIES=<%= @timeout %>
+RETRIES=<%= @retries %>
 PORT=<%= @app_port %>
 
 # FAILURE TIME TO DIE

--- a/templates/default/app-restart.sh.erb
+++ b/templates/default/app-restart.sh.erb
@@ -1,5 +1,5 @@
 #!/bin/bash
-TIMEOUT=<%= @timeout %>
+RETRIES=<%= @timeout %>
 PORT=<%= @app_port %>
 
 # FAILURE TIME TO DIE
@@ -22,20 +22,24 @@ function app_running {
   <%= @app_running_command %> && echo
 }
 
+# Is the app ready to serve traffic
+function app_ready {
+  <%= @app_ready_command %>
+}
+
 # Wait until the app is running
 function app_up {
   # Give the app *at least* a minute to boot
-  # (curl will wait 5 seconds per attempt)
-  for i in $(seq 1 $TIMEOUT)
+  for i in $(seq 1 $RETRIES)
   do
     app_running && return
     status=$?
     sleep 1
   done
+  app_ready
 
   return $status
 }
-
 
 # Remove Instance from the load balancer
 <%= "#{@bin_dir}/#{@remove_bin}" %>

--- a/test/integration/default/serverspec/app_restart_spec.rb
+++ b/test/integration/default/serverspec/app_restart_spec.rb
@@ -2,8 +2,9 @@ require 'spec_helper'
 
 describe file('/usr/local/bin/app-restart') do
   it { should be_file }
-  it { should contain "TIMEOUT=60" }
+  it { should contain "RETRIES=10" }
   it { should contain "PORT=81" }
+  it { should contain "sleep 4"}
   it { should contain "sleep 10" }
   it { should contain "curl" }
   it { should contain "haproxy-add" }

--- a/test/integration/default/serverspec/rolling_restart_spec.rb
+++ b/test/integration/default/serverspec/rolling_restart_spec.rb
@@ -6,6 +6,7 @@ describe file('/usr/local/bin/rolling-restart') do
   it { should be_owned_by 'deploy'}
   it { should contain '10.0.0.1', '10.0.0.2' }
   it { should_not contain '10.0.0.3', '10.0.0.4' }
+  it { should contain 'sleep 4'}
   it { should contain 'ssh deploy@$i /usr/local/bin/app-restart' }
   it { should contain 'function die' }
 end


### PR DESCRIPTION
Description and Impact
----------------------
This allows you to selectively add a function which determines if the app is ready to be added back into the cluster.

Updated it as well to run on tests on AWS. 

Deploy Plan
-----------
> Does Infrastructure need to know anything special about this deploy?

Rollback Plan
-------------
* To roll back this change, revert the merge with: `git revert -m 1 MERGE_SHA` and perform another deploy.

URLs
----
> Links to bug tickets or user stories.

QA Plan
-------
> Fill in scenarios below. Review [QA Best Practices](https://source.sportngin.com/page/show/1227795-qa-best-practices).

#### Happy Path Scenarios
