### PR TITLE
Rolling restart with an ELB

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,5 @@ bin/*
 
 .kitchen/
 .kitchen.local.yml
+
+.idea/

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -7,8 +7,10 @@ default[:rolling_restart][:bin_dir] = '/usr/local/bin'
 default[:rolling_restart][:template] = 'rolling-restart.sh.erb'
 default[:rolling_restart][:bin] = 'rolling-restart'
 default[:rolling_restart][:timeout] = 1800
+default[:rolling_restart][:load_balancer_type] = 'haproxy'
 
 default[:app_restart][:load_balancer_ip] = nil
+default[:app_restart][:elb_load_balancer] = nil
 
 default[:app_restart][:bin_dir] = '/usr/local/bin'
 

--- a/files/default/elb_manager.rb
+++ b/files/default/elb_manager.rb
@@ -1,0 +1,52 @@
+#!/usr/local/bin/ruby
+
+# Usage: elb_manager.rb <region_name> <elb_name> <instance_id> <register/deregister>
+
+require 'aws-sdk-core'
+
+class ELBManager
+  def initialize
+    @region_name = ARGV[0]
+    @elb_name = ARGV[1]
+    @instance_id = ARGV[2]
+    @cmd = ARGV[3]
+  end
+
+  def run
+    case @cmd
+      when 'register'
+        register_instance
+      when 'deregister'
+        deregister_instance
+      else
+        puts "Unable to parse command #{@cmd}"
+    end
+  end
+
+  private
+  def deregister_instance
+    client.deregister_instances_from_load_balancer(elb_instance_params)
+  end
+
+  private
+  def register_instance
+    client.register_instances_with_load_balancer(elb_instance_params)
+  end
+
+  private
+  def elb_instance_params
+    {
+      load_balancer_name: @elb_name,
+      instances: [{ instance_id: @instance_id }]
+    }
+  end
+
+  private
+  def client
+    @client ||= Aws::ElasticLoadBalancing::Client.new(region: @region_name)
+  end
+
+end
+
+ELBManager.new.run
+

--- a/libraries/rolling_restart.rb
+++ b/libraries/rolling_restart.rb
@@ -15,5 +15,13 @@ module RollingRestart
         data[:elastic_ip] && !data[:elastic_ip].empty?
       }.last
     end
+
+    def elb_load_balancer
+      node[:opsworks][:stack][:'elb-load-balancers'].first
+    end
+
+    def elb_load_balancer?
+      node[:rolling_restart][:load_balancer_type] == 'elb'
+    end
   end
 end

--- a/recipes/_app_restart.rb
+++ b/recipes/_app_restart.rb
@@ -2,6 +2,11 @@ extend RollingRestart::Helpers
 
 if elb_load_balancer?
   node.set[:app_restart][:elb_load_balancer] = elb_load_balancer if elb_load_balancer && !node[:app_restart][:elb_load_balancer]
+
+  cookbook_file "#{node[:app_restart][:bin_dir]}/elb_manager.rb" do
+    source 'elb_manager.rb'
+    mode '755'
+  end
 else
   node.set[:app_restart][:load_balancer_ip] = load_balancer[:private_ip] if load_balancer && !node[:app_restart][:load_balancer_ip]
 end
@@ -33,4 +38,3 @@ template "#{node[:app_restart][:bin_dir]}/#{node[:app_restart][:restart_bin]}" d
   user node[:rolling_restart][:user] || 'root'
   group node[:rolling_restart][:group] || 'root'
 end
-

--- a/recipes/_app_restart.rb
+++ b/recipes/_app_restart.rb
@@ -1,6 +1,11 @@
 extend RollingRestart::Helpers
 
-node.set[:app_restart][:load_balancer_ip] = load_balancer[:private_ip] if load_balancer && !node[:app_restart][:load_balancer_ip]
+if elb_load_balancer?
+  node.set[:app_restart][:elb_load_balancer] = elb_load_balancer if elb_load_balancer && !node[:app_restart][:elb_load_balancer]
+else
+  node.set[:app_restart][:load_balancer_ip] = load_balancer[:private_ip] if load_balancer && !node[:app_restart][:load_balancer_ip]
+end
+
 
 template "#{node[:app_restart][:bin_dir]}/#{node[:app_restart][:remove_bin]}" do
   source node[:app_restart][:remove_template]

--- a/templates/default/elb-add.sh.erb
+++ b/templates/default/elb-add.sh.erb
@@ -5,4 +5,4 @@ function say_loudly {
 }
 
 say_loudly "ADDING <%= node[:hostname] %> TO ELB: <%= node[:app_restart][:elb_load_balancer][:name] %>"
-/usr/local/bin/ruby <%= node[:app_restart][:bin_dir] %>/elb_manager.rb <%= node[:opsworks][:instance][:region] %> <%= node[:app_restart][:elb_load_balancer][:name] %> <%= node[:ec2][:instance_id] %> register
+<%= node[:app_restart][:bin_dir] %>/elb_manager.rb <%= node[:opsworks][:instance][:region] %> <%= node[:app_restart][:elb_load_balancer][:name] %> <%= node[:ec2][:instance_id] %> register

--- a/templates/default/elb-add.sh.erb
+++ b/templates/default/elb-add.sh.erb
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+function say_loudly {
+  echo "================ $@ ================"
+}
+
+say_loudly "ADDING <%= node[:hostname] %> TO ELB: <%= node[:app_restart][:elb_load_balancer][:name] %>"
+/usr/local/bin/ruby <%= node[:app_restart][:bin_dir] %>/elb_manager.rb <%= node[:opsworks][:instance][:region] %> <%= node[:app_restart][:elb_load_balancer][:name] %> <%= node[:ec2][:instance_id] %> register

--- a/templates/default/elb-remove.sh.erb
+++ b/templates/default/elb-remove.sh.erb
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+function say_loudly {
+  echo "================ $@ ================"
+}
+
+say_loudly "REMOVING <%= node[:hostname] %> TO ELB: <%= node[:app_restart][:elb_load_balancer][:name] %>"
+/usr/local/bin/ruby <%= node[:app_restart][:bin_dir] %>/elb_manager.rb <%= node[:opsworks][:instance][:region] %> <%= node[:app_restart][:elb_load_balancer][:name] %> <%= node[:ec2][:instance_id] %> register

--- a/templates/default/elb-remove.sh.erb
+++ b/templates/default/elb-remove.sh.erb
@@ -4,5 +4,5 @@ function say_loudly {
   echo "================ $@ ================"
 }
 
-say_loudly "REMOVING <%= node[:hostname] %> TO ELB: <%= node[:app_restart][:elb_load_balancer][:name] %>"
-/usr/local/bin/ruby <%= node[:app_restart][:bin_dir] %>/elb_manager.rb <%= node[:opsworks][:instance][:region] %> <%= node[:app_restart][:elb_load_balancer][:name] %> <%= node[:ec2][:instance_id] %> register
+say_loudly "REMOVING <%= node[:hostname] %> FROM ELB: <%= node[:app_restart][:elb_load_balancer][:name] %>"
+<%= node[:app_restart][:bin_dir] %>/elb_manager.rb <%= node[:opsworks][:instance][:region] %> <%= node[:app_restart][:elb_load_balancer][:name] %> <%= node[:ec2][:instance_id] %> deregister


### PR DESCRIPTION
This PR adds the ability to do a rolling restart on a stack that uses an Elastic Load Balancer.

## QA Plan
- Update cookbooks on a stack that uses an ELB
- Run a rolling restart and make sure it still works