### PR TITLE
ELB Rolling Restart should check for instance state

### DIFF
--- a/files/default/elb_manager.rb
+++ b/files/default/elb_manager.rb
@@ -36,16 +36,15 @@ class ELBManager
 
   private
   def instance_ready?
-    60.times do |i|
+    60.times do
       elb_state = client.describe_instance_health(@elb_name).to_h
       instance = elb_state[:instance_states].select{ |instance| instance[:instance_id] == @instance_id }[0]
       instance_state = instance[:state]
       if instance_state == 'InService'
         return true
-      elsif i > 59
-        return false
       end
     end
+    false
   end
 
   private

--- a/files/default/elb_manager.rb
+++ b/files/default/elb_manager.rb
@@ -37,12 +37,13 @@ class ELBManager
   private
   def instance_ready?
     60.times do
-      elb_state = client.describe_instance_health(@elb_name).to_h
+      elb_state = client.describe_instance_health(load_balancer_name: @elb_name).to_h
       instance = elb_state[:instance_states].select{ |instance| instance[:instance_id] == @instance_id }[0]
       instance_state = instance[:state]
       if instance_state == 'InService'
         return true
       end
+      sleep 1
     end
     false
   end


### PR DESCRIPTION
Description and Impact
----------------------
> What impact does this change have for production?

Makes the ELB rolling restart wait up to a minute for an instance to be "In Service" in the ELB before proceeding or blows up if it's not  ready.

Deploy Plan
-----------
> Does Platform Operations need to know anything special about this deploy? Are migrations present?

Rollback Plan
-------------
* To roll back this change, revert the merge with: `git revert -m 1 MERGE_SHA` and perform another deploy.

URLs
----
> Links to bug tickets or user stories.

QA Plan
-------
- [x] Verify that rolling restart works on commissioner 

