### PR TITLE
Use aws-sdk instead of aws-sdk-core

### DIFF
--- a/files/default/elb_manager.rb
+++ b/files/default/elb_manager.rb
@@ -2,7 +2,7 @@
 
 # Usage: elb_manager.rb <region_name> <elb_name> <instance_id> <register/deregister>
 
-require 'aws-sdk-core'
+require 'aws-sdk'
 
 class ELBManager
   def initialize


### PR DESCRIPTION
What
----------------------
Use the aws-sdk gem instead of aws-sdk-core gem

Why
----------------------
The core gem has been gimped and now every resource is it's own gem.
