### PR TITLE
Go back to using aws-sdk-core and install the right version

### DIFF
--- a/files/default/elb_manager.rb
+++ b/files/default/elb_manager.rb
@@ -2,7 +2,7 @@
 
 # Usage: elb_manager.rb <region_name> <elb_name> <instance_id> <register/deregister>
 
-require 'aws-sdk'
+require 'aws-sdk-core'
 
 class ELBManager
   def initialize

--- a/recipes/_app_restart.rb
+++ b/recipes/_app_restart.rb
@@ -2,6 +2,9 @@ extend RollingRestart::Helpers
 
 if elb_load_balancer?
   node.set[:app_restart][:elb_load_balancer] = elb_load_balancer if elb_load_balancer && !node[:app_restart][:elb_load_balancer]
+  gem_package aws-sdk-core do
+    version '2.10'
+  end
 
   cookbook_file "#{node[:app_restart][:bin_dir]}/elb_manager.rb" do
     source 'elb_manager.rb'

--- a/recipes/_app_restart.rb
+++ b/recipes/_app_restart.rb
@@ -2,7 +2,7 @@ extend RollingRestart::Helpers
 
 if elb_load_balancer?
   node.set[:app_restart][:elb_load_balancer] = elb_load_balancer if elb_load_balancer && !node[:app_restart][:elb_load_balancer]
-  gem_package aws-sdk-core do
+  gem_package 'aws-sdk-core' do
     version '2.10'
   end
 


### PR DESCRIPTION
What
----------------------
Revert changes to use aws-sdk and install 2.10 version of aws-sdk-core where it's used.

Why
----------------------
Locking the version seems like a better idea.

Rollback Plan
-------------
* To roll back this change, revert the merge with: `git revert -m 1 MERGE_SHA` and perform another deploy.