### PR TITLE
Make this cookbook compatible with Chef 12

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -10,7 +10,7 @@ default[:rolling_restart][:timeout] = 1800
 default[:rolling_restart][:load_balancer_type] = 'haproxy'
 
 default[:app_restart][:load_balancer_ip] = nil
-default[:app_restart][:elb_load_balancer] = nil
+default[:app_restart][:elb_load_balancer_name] = nil
 
 default[:app_restart][:bin_dir] = '/usr/local/bin'
 

--- a/libraries/rolling_restart.rb
+++ b/libraries/rolling_restart.rb
@@ -57,11 +57,11 @@ module RollingRestart
       end
     end
 
-    def elb_load_balancer
+    def elb_load_balancer_name
       if chef_11?
-        node[:opsworks][:stack][:'elb-load-balancers'].first
+        node[:opsworks][:stack][:'elb-load-balancers'].first[:name]
       else
-        search("aws_opsworks_elastic_load_balancer").first
+        search("aws_opsworks_elastic_load_balancer").first[:elastic_load_balancer_name]
       end
     end
 

--- a/libraries/rolling_restart.rb
+++ b/libraries/rolling_restart.rb
@@ -69,7 +69,7 @@ module RollingRestart
       node[:rolling_restart][:load_balancer_type] == 'elb'
     end
 
-    def get_region
+    def get_instance_region
       if chef_11?
         node[:opsworks][:instance][:region]
       else

--- a/libraries/rolling_restart.rb
+++ b/libraries/rolling_restart.rb
@@ -28,7 +28,7 @@ module RollingRestart
         instances = node[:opsworks][:layers].map { |layer_name, layer_attrs| layer_attrs[:instances] if layer_name.to_s.include?("app") }
       else
         app_layer = search("aws_opsworks_layer").select{ |l| l[:shortname].include?("app") }.first
-        layer_id = app_layer['layer_id']
+        layer_id = app_layer[:layer_id]
         instances = search("aws_opsworks_instance").select{ |i| i[:layer_ids].include?(layer_id) }
       end
 

--- a/libraries/rolling_restart.rb
+++ b/libraries/rolling_restart.rb
@@ -73,7 +73,7 @@ module RollingRestart
       if chef_11?
         node[:opsworks][:instance][:region]
       else
-        search("aws_opsworks_instance", "self:true").first(:availability_zone).chop
+        search("aws_opsworks_instance", "self:true").first[:availability_zone].chop
       end
     end
   end

--- a/libraries/rolling_restart.rb
+++ b/libraries/rolling_restart.rb
@@ -68,5 +68,13 @@ module RollingRestart
     def elb_load_balancer?
       node[:rolling_restart][:load_balancer_type] == 'elb'
     end
+
+    def get_region
+      if chef_11?
+        node[:opsworks][:instance][:region]
+      else
+        search("aws_opsworks_instance", "self:true").first(:availability_zone).chop
+      end
+    end
   end
 end

--- a/libraries/rolling_restart.rb
+++ b/libraries/rolling_restart.rb
@@ -1,19 +1,23 @@
 module RollingRestart
   module Helpers
+    def chef_11?
+      node[:opsworks]
+    end
+
     def app_instances
-      if node[:opsworks]
+      if chef_11?
         node[:opsworks][:layers].map { |layer_name, layer_attrs|
           layer_attrs[:instances] if layer_name.to_s.include?("app")
         }.compact.flatten(1).reduce(&:merge) # Flatten down the list of instances to a hash of { hostname: instance_data }
       else
-        app_layer = search("aws_opsworks_layer").select{ |l| l['shortname'].include?("app") }
+        app_layer = search("aws_opsworks_layer").select{ |l| l['shortname'].include?("app") }.first
         layer_id = app_layer['layer_id']
         instances = search("aws_opsworks_instance").select{ |i| i['layer_ids'].include?(layer_id) }.compact.flatten(1).reduce(&:merge)
       end
     end
 
     def instances
-      if node[:opsworks]
+      if chef_11?
         node[:opsworks][:layers].map { |layer_name, layer_attrs| layer_attrs[:instances] }.compact.flatten(1).reduce(&:merge)
       else
         instances = search("aws_opsworks_instance")
@@ -21,13 +25,19 @@ module RollingRestart
     end
 
     def load_balancer
-      instances.detect{|hostname, data|
-        data[:elastic_ip] && !data[:elastic_ip].empty?
-      }.last
+      if chef_11?
+        instances.detect{ |hostname, data|
+          data[:elastic_ip] && !data[:elastic_ip].empty?
+        }.last
+      else
+        instances.detect{ |hostname, data|
+          data['elastic_ip'] != "null"
+        }.last
+      end
     end
 
     def elb_load_balancer
-      if node[:opsworks]
+      if chef_11?
         node[:opsworks][:stack][:'elb-load-balancers'].first
       else
         search("aws_opsworks_elastic_load_balancer").first

--- a/recipes/_app_restart.rb
+++ b/recipes/_app_restart.rb
@@ -14,11 +14,13 @@ else
   node.set[:app_restart][:load_balancer_ip] = load_balancer[:private_ip] if load_balancer && !node[:app_restart][:load_balancer_ip]
 end
 
+region = get_instance_region
+
 
 template "#{node[:app_restart][:bin_dir]}/#{node[:app_restart][:remove_bin]}" do
   source node[:app_restart][:remove_template]
   cookbook node[:rolling_restart][:cookbook]
-  variables(node[:app_restart])
+  variables(node: node[:app_restart], region: region)
   mode '0755'
   user node[:rolling_restart][:user] || 'root'
   group node[:rolling_restart][:group] || 'root'
@@ -27,7 +29,7 @@ end
 template "#{node[:app_restart][:bin_dir]}/#{node[:app_restart][:add_bin]}" do
   source node[:app_restart][:add_template]
   cookbook node[:rolling_restart][:cookbook]
-  variables(node[:app_restart])
+  variables(node: node[:app_restart], region: region)
   mode '0755'
   user node[:rolling_restart][:user] || 'root'
   group node[:rolling_restart][:group] || 'root'

--- a/recipes/_app_restart.rb
+++ b/recipes/_app_restart.rb
@@ -1,7 +1,7 @@
 extend RollingRestart::Helpers
 
 if elb_load_balancer?
-  node.set[:app_restart][:elb_load_balancer] = elb_load_balancer if elb_load_balancer && !node[:app_restart][:elb_load_balancer]
+  node.set[:app_restart][:elb_load_balancer_name] = elb_load_balancer_name if elb_load_balancer_name && !node[:app_restart][:elb_load_balancer_name]
   gem_package 'aws-sdk-core' do
     version '2.10'
   end

--- a/recipes/_app_restart.rb
+++ b/recipes/_app_restart.rb
@@ -2,6 +2,7 @@ extend RollingRestart::Helpers
 
 if elb_load_balancer?
   node.set[:app_restart][:elb_load_balancer_name] = elb_load_balancer_name if elb_load_balancer_name && !node[:app_restart][:elb_load_balancer_name]
+  
   gem_package 'aws-sdk-core' do
     version '2.10'
   end

--- a/recipes/_app_restart.rb
+++ b/recipes/_app_restart.rb
@@ -2,7 +2,7 @@ extend RollingRestart::Helpers
 
 if elb_load_balancer?
   node.set[:app_restart][:elb_load_balancer_name] = elb_load_balancer_name if elb_load_balancer_name && !node[:app_restart][:elb_load_balancer_name]
-  
+
   gem_package 'aws-sdk-core' do
     version '2.10'
   end
@@ -16,7 +16,6 @@ else
 end
 
 region = get_instance_region
-
 
 template "#{node[:app_restart][:bin_dir]}/#{node[:app_restart][:remove_bin]}" do
   source node[:app_restart][:remove_template]

--- a/recipes/_rolling_restart.rb
+++ b/recipes/_rolling_restart.rb
@@ -19,7 +19,7 @@ template "#{node[:rolling_restart][:bin_dir]}/#{node[:rolling_restart][:bin]}" d
     :before_restart_command => node[:rolling_restart][:before_command],
     :after_restart_command => node[:rolling_restart][:after_command],
     :app_restart_command => "#{node[:app_restart][:bin_dir]}/#{node[:app_restart][:restart_bin]}",
-    :ip_addresses => instances.map{|hostname, data| data[:private_ip] },
+    :ip_addresses => instances.map{ |hostname, data| data[:private_ip] },
     :user => user
   )
 end

--- a/templates/default/app-restart.sh.erb
+++ b/templates/default/app-restart.sh.erb
@@ -23,23 +23,23 @@ function app_running {
 }
 
 <% if @app_ready_command %>
-  function app_ready {
-    <%= @app_ready_command %>
-  }
-<% end %>
+function app_ready {
+  <%= @app_ready_command %>
+}
 
+<% end %>
 <% if @before_command %>
-  function before_command {
-    <%= @before_command %>
-  }
-<% end %>
+function before_command {
+  <%= @before_command %>
+}
 
+<% end %>
 <% if @after_command %>
-  function after_command {
-    <%= @after_command %>
-  }
-<% end %>
+function after_command {
+  <%= @after_command %>
+}
 
+<% end %>
 # Wait until the app is running
 function app_up {
   # Give the app *at least* a minute to boot
@@ -63,10 +63,10 @@ finish_requests
 
 # Restart the application
 say_loudly "ATTEMPTING to RESTART <%= node[:hostname] %>"
-<%= @restart_command %> || die_loudly "RESTART FAILED 1 <%= node[:hostname] %>"
+<%= @restart_command %> || die_loudly "RESTART FAILED <%= node[:hostname] %>"
 
 # Wait for the app to come back up or fail the restart
-app_up || die_loudly "RESTART FAILED 2 <%= node[:hostname] %>"
+app_up || die_loudly "RESTART FAILED <%= node[:hostname] %>"
 say_loudly "RESTART COMPLETE <%= node[:hostname] %>"
 
 # Add Instance back into the load balancer

--- a/templates/default/app-restart.sh.erb
+++ b/templates/default/app-restart.sh.erb
@@ -23,23 +23,23 @@ function app_running {
 }
 
 <% if @app_ready_command %>
-function app_ready {
-  <%= @app_ready_command %>
-}
-
+  function app_ready {
+    <%= @app_ready_command %>
+  }
 <% end %>
+
 <% if @before_command %>
-function before_command {
-  <%= @before_command %>
-}
-
+  function before_command {
+    <%= @before_command %>
+  }
 <% end %>
+
 <% if @after_command %>
-function after_command {
-  <%= @after_command %>
-}
-
+  function after_command {
+    <%= @after_command %>
+  }
 <% end %>
+
 # Wait until the app is running
 function app_up {
   # Give the app *at least* a minute to boot
@@ -63,10 +63,10 @@ finish_requests
 
 # Restart the application
 say_loudly "ATTEMPTING to RESTART <%= node[:hostname] %>"
-<%= @restart_command %> || die_loudly "RESTART FAILED <%= node[:hostname] %>"
+<%= @restart_command %> || die_loudly "RESTART FAILED 1 <%= node[:hostname] %>"
 
 # Wait for the app to come back up or fail the restart
-app_up || die_loudly "RESTART FAILED <%= node[:hostname] %>"
+app_up || die_loudly "RESTART FAILED 2 <%= node[:hostname] %>"
 say_loudly "RESTART COMPLETE <%= node[:hostname] %>"
 
 # Add Instance back into the load balancer

--- a/templates/default/elb-add.sh.erb
+++ b/templates/default/elb-add.sh.erb
@@ -4,14 +4,5 @@ function say_loudly {
   echo "================ $@ ================"
 }
 
-function get_region {
-  if [ <%= node[:opsworks] %> ]; then
-    region=<%= node[:opsworks][:instance][:region] %>
-  else
-    region=<%= search("aws_opsworks_instance", "self:true").first['availability_zone'].chop %>
-  fi
-}
-
-get_region
 say_loudly "ADDING <%= node[:hostname] %> TO ELB: <%= node[:app_restart][:elb_load_balancer][:name] %>"
-<%= node[:app_restart][:bin_dir] %>/elb_manager.rb $region <%= node[:app_restart][:elb_load_balancer][:name] %> <%= node[:ec2][:instance_id] %> register
+<%= node[:app_restart][:bin_dir] %>/elb_manager.rb $1 <%= node[:app_restart][:elb_load_balancer][:name] %> <%= node[:ec2][:instance_id] %> register

--- a/templates/default/elb-add.sh.erb
+++ b/templates/default/elb-add.sh.erb
@@ -4,5 +4,5 @@ function say_loudly {
   echo "================ $@ ================"
 }
 
-say_loudly "ADDING <%= node[:hostname] %> TO ELB: <%= node[:app_restart][:elb_load_balancer][:name] %>"
-<%= node[:app_restart][:bin_dir] %>/elb_manager.rb $1 <%= node[:app_restart][:elb_load_balancer][:name] %> <%= node[:ec2][:instance_id] %> register
+say_loudly "ADDING <%= @node[:hostname] %> TO ELB: <%= @node[:app_restart][:elb_load_balancer][:name] %>"
+<%= @node[:app_restart][:bin_dir] %>/elb_manager.rb @region <%= @node[:app_restart][:elb_load_balancer][:name] %> <%= @node[:ec2][:instance_id] %> register

--- a/templates/default/elb-add.sh.erb
+++ b/templates/default/elb-add.sh.erb
@@ -4,5 +4,14 @@ function say_loudly {
   echo "================ $@ ================"
 }
 
+function get_region {
+  if [ <%= node[:opsworks] %> ]; then
+    region=<%= node[:opsworks][:instance][:region] %>
+  else
+    region=<%= search("aws_opsworks_instance", "self:true").first['availability_zone'].chop %>
+  fi
+}
+
+get_region
 say_loudly "ADDING <%= node[:hostname] %> TO ELB: <%= node[:app_restart][:elb_load_balancer][:name] %>"
-<%= node[:app_restart][:bin_dir] %>/elb_manager.rb <%= node[:opsworks][:instance][:region] %> <%= node[:app_restart][:elb_load_balancer][:name] %> <%= node[:ec2][:instance_id] %> register
+<%= node[:app_restart][:bin_dir] %>/elb_manager.rb $region <%= node[:app_restart][:elb_load_balancer][:name] %> <%= node[:ec2][:instance_id] %> register

--- a/templates/default/elb-add.sh.erb
+++ b/templates/default/elb-add.sh.erb
@@ -5,4 +5,7 @@ function say_loudly {
 }
 
 say_loudly "ADDING <%= @node[:hostname] %> TO ELB: <%= @node[:app_restart][:elb_load_balancer_name] %>"
+
+say_loudly "ADDING WITH REGION: <%= @region %>"
+
 <%= @node[:app_restart][:bin_dir] %>/elb_manager.rb @region <%= @node[:app_restart][:elb_load_balancer_name] %> <%= @node[:ec2][:instance_id] %> register

--- a/templates/default/elb-add.sh.erb
+++ b/templates/default/elb-add.sh.erb
@@ -5,7 +5,4 @@ function say_loudly {
 }
 
 say_loudly "ADDING <%= @node[:hostname] %> TO ELB: <%= @node[:app_restart][:elb_load_balancer_name] %>"
-
-say_loudly "ADDING WITH REGION: <%= @region %>"
-
 <%= @node[:app_restart][:bin_dir] %>/elb_manager.rb @region <%= @node[:app_restart][:elb_load_balancer_name] %> <%= @node[:ec2][:instance_id] %> register

--- a/templates/default/elb-add.sh.erb
+++ b/templates/default/elb-add.sh.erb
@@ -5,4 +5,4 @@ function say_loudly {
 }
 
 say_loudly "ADDING <%= @node[:hostname] %> TO ELB: <%= @node[:app_restart][:elb_load_balancer_name] %>"
-<%= @node[:app_restart][:bin_dir] %>/elb_manager.rb @region <%= @node[:app_restart][:elb_load_balancer_name] %> <%= @node[:ec2][:instance_id] %> register
+<%= @node[:app_restart][:bin_dir] %>/elb_manager.rb <%= @region %> <%= @node[:app_restart][:elb_load_balancer_name] %> <%= @node[:ec2][:instance_id] %> register

--- a/templates/default/elb-add.sh.erb
+++ b/templates/default/elb-add.sh.erb
@@ -4,5 +4,5 @@ function say_loudly {
   echo "================ $@ ================"
 }
 
-say_loudly "ADDING <%= @node[:hostname] %> TO ELB: <%= @node[:app_restart][:elb_load_balancer][:name] %>"
-<%= @node[:app_restart][:bin_dir] %>/elb_manager.rb @region <%= @node[:app_restart][:elb_load_balancer][:name] %> <%= @node[:ec2][:instance_id] %> register
+say_loudly "ADDING <%= @node[:hostname] %> TO ELB: <%= @node[:app_restart][:elb_load_balancer_name] %>"
+<%= @node[:app_restart][:bin_dir] %>/elb_manager.rb @region <%= @node[:app_restart][:elb_load_balancer_name] %> <%= @node[:ec2][:instance_id] %> register

--- a/templates/default/elb-remove.sh.erb
+++ b/templates/default/elb-remove.sh.erb
@@ -4,5 +4,5 @@ function say_loudly {
   echo "================ $@ ================"
 }
 
-say_loudly "REMOVING <%= node[:hostname] %> FROM ELB: <%= node[:app_restart][:elb_load_balancer][:name] %>"
-<%= node[:app_restart][:bin_dir] %>/elb_manager.rb $1 <%= node[:app_restart][:elb_load_balancer][:name] %> <%= node[:ec2][:instance_id] %> deregister
+say_loudly "REMOVING <%= @node[:hostname] %> FROM ELB: <%= @node[:app_restart][:elb_load_balancer][:name] %>"
+<%= @node[:app_restart][:bin_dir] %>/elb_manager.rb @region <%= @node[:app_restart][:elb_load_balancer][:name] %> <%= @node[:ec2][:instance_id] %> deregister

--- a/templates/default/elb-remove.sh.erb
+++ b/templates/default/elb-remove.sh.erb
@@ -5,7 +5,4 @@ function say_loudly {
 }
 
 say_loudly "REMOVING <%= @node[:hostname] %> FROM ELB: <%= @node[:app_restart][:elb_load_balancer_name] %>"
-
-say_loudly "REMOVING WITH REGION: <%= @region %>"
-
 <%= @node[:app_restart][:bin_dir] %>/elb_manager.rb @region <%= @node[:app_restart][:elb_load_balancer_name] %> <%= @node[:ec2][:instance_id] %> deregister

--- a/templates/default/elb-remove.sh.erb
+++ b/templates/default/elb-remove.sh.erb
@@ -4,14 +4,5 @@ function say_loudly {
   echo "================ $@ ================"
 }
 
-function get_region {
-  if [ <%= node[:opsworks] %> ]; then
-    region=<%= node[:opsworks][:instance][:region] %>
-  else
-    region=<%= search("aws_opsworks_instance", "self:true").first['availability_zone'].chop %>
-  fi
-}
-
-get_region
 say_loudly "REMOVING <%= node[:hostname] %> FROM ELB: <%= node[:app_restart][:elb_load_balancer][:name] %>"
-<%= node[:app_restart][:bin_dir] %>/elb_manager.rb $region <%= node[:app_restart][:elb_load_balancer][:name] %> <%= node[:ec2][:instance_id] %> deregister
+<%= node[:app_restart][:bin_dir] %>/elb_manager.rb $1 <%= node[:app_restart][:elb_load_balancer][:name] %> <%= node[:ec2][:instance_id] %> deregister

--- a/templates/default/elb-remove.sh.erb
+++ b/templates/default/elb-remove.sh.erb
@@ -4,5 +4,14 @@ function say_loudly {
   echo "================ $@ ================"
 }
 
+function get_region {
+  if [ <%= node[:opsworks] %> ]; then
+    region=<%= node[:opsworks][:instance][:region] %>
+  else
+    region=<%= search("aws_opsworks_instance", "self:true").first['availability_zone'].chop %>
+  fi
+}
+
+get_region
 say_loudly "REMOVING <%= node[:hostname] %> FROM ELB: <%= node[:app_restart][:elb_load_balancer][:name] %>"
-<%= node[:app_restart][:bin_dir] %>/elb_manager.rb <%= node[:opsworks][:instance][:region] %> <%= node[:app_restart][:elb_load_balancer][:name] %> <%= node[:ec2][:instance_id] %> deregister
+<%= node[:app_restart][:bin_dir] %>/elb_manager.rb $region <%= node[:app_restart][:elb_load_balancer][:name] %> <%= node[:ec2][:instance_id] %> deregister

--- a/templates/default/elb-remove.sh.erb
+++ b/templates/default/elb-remove.sh.erb
@@ -4,5 +4,5 @@ function say_loudly {
   echo "================ $@ ================"
 }
 
-say_loudly "REMOVING <%= @node[:hostname] %> FROM ELB: <%= @node[:app_restart][:elb_load_balancer][:name] %>"
-<%= @node[:app_restart][:bin_dir] %>/elb_manager.rb @region <%= @node[:app_restart][:elb_load_balancer][:name] %> <%= @node[:ec2][:instance_id] %> deregister
+say_loudly "REMOVING <%= @node[:hostname] %> FROM ELB: <%= @node[:app_restart][:elb_load_balancer_name] %>"
+<%= @node[:app_restart][:bin_dir] %>/elb_manager.rb @region <%= @node[:app_restart][:elb_load_balancer_name] %> <%= @node[:ec2][:instance_id] %> deregister

--- a/templates/default/elb-remove.sh.erb
+++ b/templates/default/elb-remove.sh.erb
@@ -5,4 +5,4 @@ function say_loudly {
 }
 
 say_loudly "REMOVING <%= @node[:hostname] %> FROM ELB: <%= @node[:app_restart][:elb_load_balancer_name] %>"
-<%= @node[:app_restart][:bin_dir] %>/elb_manager.rb @region <%= @node[:app_restart][:elb_load_balancer_name] %> <%= @node[:ec2][:instance_id] %> deregister
+<%= @node[:app_restart][:bin_dir] %>/elb_manager.rb <%= @region %> <%= @node[:app_restart][:elb_load_balancer_name] %> <%= @node[:ec2][:instance_id] %> deregister

--- a/templates/default/elb-remove.sh.erb
+++ b/templates/default/elb-remove.sh.erb
@@ -5,4 +5,7 @@ function say_loudly {
 }
 
 say_loudly "REMOVING <%= @node[:hostname] %> FROM ELB: <%= @node[:app_restart][:elb_load_balancer_name] %>"
+
+say_loudly "REMOVING WITH REGION: <%= @region %>"
+
 <%= @node[:app_restart][:bin_dir] %>/elb_manager.rb @region <%= @node[:app_restart][:elb_load_balancer_name] %> <%= @node[:ec2][:instance_id] %> deregister

--- a/templates/default/haproxy-add.sh.erb
+++ b/templates/default/haproxy-add.sh.erb
@@ -4,5 +4,5 @@ function say_loudly {
   echo "================ $@ ================"
 }
 
-say_loudly "ADDING <%= node[:hostname] %> TO LB: <%= node[:app_restart][:load_balancer_ip] %>"
-sudo -u <%= node[:rolling_restart][:ssh][:user] %> ssh <%= node[:rolling_restart][:ssh][:user] %>@<%= node[:app_restart][:load_balancer_ip] %> "sudo sed -i -r 's/^#*(.*server.*<%= node[:cloud][:local_ipv4] %>.*)/\1/g' /etc/haproxy/haproxy.cfg; sudo /etc/init.d/haproxy reload"
+say_loudly "ADDING <%= @node[:hostname] %> TO LB: <%= @node[:app_restart][:load_balancer_ip] %>"
+sudo -u <%= @node[:rolling_restart][:ssh][:user] %> ssh <%= @node[:rolling_restart][:ssh][:user] %>@<%= @node[:app_restart][:load_balancer_ip] %> "sudo sed -i -r 's/^#*(.*server.*<%= @node[:cloud][:local_ipv4] %>.*)/\1/g' /etc/haproxy/haproxy.cfg; sudo /etc/init.d/haproxy reload"

--- a/templates/default/haproxy-remove.sh.erb
+++ b/templates/default/haproxy-remove.sh.erb
@@ -4,5 +4,5 @@ function say_loudly {
   echo "================ $@ ================"
 }
 
-say_loudly "REMOVING <%= node[:hostname] %> FROM LB: <%= node[:app_restart][:load_balancer_ip] %>"
-sudo -u <%= node[:rolling_restart][:ssh][:user] %> ssh <%= node[:rolling_restart][:ssh][:user] %>@<%= node[:app_restart][:load_balancer_ip] %> "sudo sed -i -r 's/(.*server.*<%= node[:cloud][:local_ipv4] %>.*)/#&/g' /etc/haproxy/haproxy.cfg; sudo /etc/init.d/haproxy reload"
+say_loudly "REMOVING <%= @node[:hostname] %> FROM LB: <%= @node[:app_restart][:load_balancer_ip] %>"
+sudo -u <%= @node[:rolling_restart][:ssh][:user] %> ssh <%= @node[:rolling_restart][:ssh][:user] %>@<%= @node[:app_restart][:load_balancer_ip] %> "sudo sed -i -r 's/(.*server.*<%= @node[:cloud][:local_ipv4] %>.*)/#&/g' /etc/haproxy/haproxy.cfg; sudo /etc/init.d/haproxy reload"


### PR DESCRIPTION
What
----------------------
Allow this cookbook to work with stacks that are running Chef 12.

Why
----------------------
Because we may eventually want to switch over to Chef 12.

Deploy Plan
-----------
* Merge into production
* Jump over to https://github.com/sportngin/trackwrestling-cookbook/pull/27 and edit it to use the newest commit SHA

Rollback Plan
-------------
* To roll back this change, revert the merge with: `git revert -m 1 MERGE_SHA` and perform another deploy.

URLs
----
https://sportngin.atlassian.net/browse/IS-6902

QA Plan
-------
- [x] Put on some servers that are running Chef 12 and make sure that the appropriate tools are set and files are present to run a rolling restart
- [x] QA plan [here](https://github.com/sportngin/trackwrestling-cookbook/pull/27)
  