### PR TITLE
Filter out instances that are not currently online when configuring

### DIFF
--- a/libraries/rolling_restart.rb
+++ b/libraries/rolling_restart.rb
@@ -29,7 +29,7 @@ module RollingRestart
       else
         app_layer = search("aws_opsworks_layer").select{ |l| l[:shortname].include?("app") }.first
         layer_id = app_layer[:layer_id]
-        instances = search("aws_opsworks_instance").select{ |i| i[:layer_ids].include?(layer_id) }
+        instances = search("aws_opsworks_instance").select{ |i| (i[:layer_ids].include?(layer_id)) && (i[:status] == "online") }
       end
 
       make_hash(instances)


### PR DESCRIPTION
What
----------------------
Include a filter to get only instances that are online when gathering app instances.

Why
----------------------
So that it won't track instances that aren't fully online, leading to failed rolling restarts.

Deploy Plan
-----------
> Does Platform Operations need to know anything special about this deploy? Are migrations present?

Rollback Plan
-------------
* To roll back this change, revert the merge with: `git revert -m 1 MERGE_SHA` and perform another deploy.

URLs
----
> Links to bug tickets or user stories.

QA Plan
-------
- [x] Have Trackwrestling test out this branch of the cookbook
- [x] Run a configure
- [x] Only 2 IPs are in the rolling restart file on the cron server
- [x] Add a server to the tomcat layer and start it
- [x] Verify 3 IPs are now in the rolling restart file
- [x] Verify a `gordy deploy` with rolling restart succeeds
- [x] Stop the test server you added
- [x] Verify 2 IPs are now in the rolling restart file
- [x] Verify a `gordy deploy` with rolling restart succeeds