### PR TITLE
Add option to override cookbook for app_restart templates

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -16,12 +16,15 @@ default[:app_restart][:bin_dir] = '/usr/local/bin'
 
 default[:app_restart][:add_bin] = 'haproxy-add'
 default[:app_restart][:add_template] = 'haproxy-add.sh.erb'
+default[:app_restart][:add_template_cookbook] = 'opsworks-rolling-restart'
 
 default[:app_restart][:remove_bin] = 'haproxy-remove'
 default[:app_restart][:remove_template] = 'haproxy-remove.sh.erb'
+default[:app_restart][:remove_template_cookbook] = 'opsworks-rolling-restart'
 
 default[:app_restart][:restart_bin] = 'app-restart'
 default[:app_restart][:restart_template] = 'app-restart.sh.erb'
+default[:app_restart][:restart_template_cookbook] = 'opsworks-rolling-restart'
 
 default[:app_restart][:app_running_command] = 'curl --silent --fail --max-time 5 127.0.0.1:$PORT/okcomputer'
 default[:app_restart][:finished_requests_command] = 'sleep 10'

--- a/recipes/_app_restart.rb
+++ b/recipes/_app_restart.rb
@@ -19,7 +19,7 @@ region = get_instance_region
 
 template "#{node[:app_restart][:bin_dir]}/#{node[:app_restart][:remove_bin]}" do
   source node[:app_restart][:remove_template]
-  cookbook node[:rolling_restart][:cookbook]
+  cookbook node[:app_restart][:remove_template_cookbook]
   variables(node: node[:app_restart], region: region)
   mode '0755'
   user node[:rolling_restart][:user] || 'root'
@@ -28,7 +28,7 @@ end
 
 template "#{node[:app_restart][:bin_dir]}/#{node[:app_restart][:add_bin]}" do
   source node[:app_restart][:add_template]
-  cookbook node[:rolling_restart][:cookbook]
+  cookbook node[:app_restart][:add_template_cookbook]
   variables(node: node[:app_restart], region: region)
   mode '0755'
   user node[:rolling_restart][:user] || 'root'
@@ -37,7 +37,7 @@ end
 
 template "#{node[:app_restart][:bin_dir]}/#{node[:app_restart][:restart_bin]}" do
   source node[:app_restart][:restart_template]
-  cookbook node[:rolling_restart][:cookbook]
+  cookbook node[:app_restart][:restart_template_cookbook]
   variables(node[:app_restart])
   mode '0755'
   user node[:rolling_restart][:user] || 'root'


### PR DESCRIPTION
What
----------------------
Adding attribute to control which cookbook app_restart templates are pulled from.

Why
----------------------
Individual templates can be overriden.
